### PR TITLE
[Fix] Updates confirm announcement controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsb-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Core API for the BSB platform, providing backend services and data access via REST.",
   "main": "server.js",
   "type": "module",

--- a/src/controllers/announcement.controller.js
+++ b/src/controllers/announcement.controller.js
@@ -440,6 +440,7 @@ const confirmAnnouncement = async (req, res) => {
     return res.status(200).json({
       status: "success",
       message: "Announcement confirmed successfully.",
+      createdAnnouncementId: confirmation.announcementId
     });
   } catch (err) {
     console.error("Erro ao confirmar anúncio:", err);


### PR DESCRIPTION
This PR updates the announcement confirmation controller so it returns the created announcement id, as `createdAnnouncementId`.